### PR TITLE
Remove just-comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -121,7 +121,7 @@ google_analytics: "UA-121685077-1"
 # disqus: ""
 
 # If you want to use JustComments fill with the API Key
-just-comments: "ce30a8f0-615e-4123-b660-d2e23742a163"
+# just-comments:
 
 # To use Facebook Comments, fill in a Facebook App ID
 # fb_comment_id: ""

--- a/_includes/just_comments.html
+++ b/_includes/just_comments.html
@@ -1,4 +1,0 @@
-{%- if site.just-comments -%}
-<div class="just-comments" data-apikey="{{site.just-comments}}"></div>
-<script async src="https://just-comments.com/w.js"></script>
-{%- endif -%}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -16,9 +16,6 @@ layout: base
         <div class="staticman-comments">
           {% include staticman-comments.html %}
         </div>
-        <div class="justcomments-comments">
-          {% include just_comments.html %}
-        </div>
 	    {% endif %}
     </div>
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -75,9 +75,6 @@ layout: base
         <div class="staticman-comments">
           {% include staticman-comments.html %}
         </div>
-        <div class="justcomments-comments">
-          {% include just_comments.html %}
-        </div>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
Credits expired, will go for [disqus](https://disqus.com/) instead ¯\_(ツ)_/¯ 